### PR TITLE
Support sub templates that are async

### DIFF
--- a/lib/ejx/assets/ejx.js
+++ b/lib/ejx/assets/ejx.js
@@ -42,7 +42,9 @@ export function append(items, to, escape, promises, promiseResults) {
           }
       }));
     } else if (items === undefined && promiseResults != undefined) {
-      promiseResults.forEach((r) => { append(r, to, escape, promises) });
+      Promise.all(promises).then((results) => {
+          promiseResults.forEach((r) => { append(r, to, escape, promises) });
+      })
     } else if (typeof items === 'string') {
       if (escape) {
         to[method](items);

--- a/lib/ejx/template/subtemplate.rb
+++ b/lib/ejx/template/subtemplate.rb
@@ -10,6 +10,7 @@ class EJX::Template::Subtemplate
 
   def to_js(indentation: 4, var_generator: nil, append: "__output")
     output = ''
+    async_for_each = @children.first =~ /async\s+function\s*\([^\)]*\)\s*\{\s*\Z/m || @children.first =~ /async(\s*\([^\)]*\)|\s+\S+)?\s*=>\s*\{/m
     already_assigned = @children.first =~ /\A\s*(var|const|let)\s+(\S+)/
     global_output_var = already_assigned ? $2 : var_generator.next
     output_var = var_generator.next
@@ -23,6 +24,17 @@ class EJX::Template::Subtemplate
     end
 
     output << "#{' '*(indentation+4)}var #{output_var} = [];\n"
+    if async_for_each
+      indentation += 4
+      output << "#{' '*(indentation)}var resolve, error;\n"
+      output << "#{' '*(indentation)}var thisPromise = new Promise((r, e) => {\n"
+      output << "#{' '*(indentation+2)}resolve = r;\n"
+      output << "#{' '*(indentation+2)}error = e;\n"
+      output << "#{' '*(indentation)}});\n"
+      output << "#{' '*(indentation)}__promises.push(thisPromise);\n"
+      output << ' '*(indentation) << "try {\n";
+    end
+    
     @children[1..-2].each do |child|
       output << case child
       when EJX::Template::String
@@ -35,8 +47,17 @@ class EJX::Template::Subtemplate
     if !already_assigned
       output << ' '*(indentation+4) << "#{global_output_var}.push(#{output_var});\n" if @append
     end
-    output << ' '*(indentation+4) << "return #{output_var};\n";
+    if async_for_each
+      output << ' '*(indentation+4) << "resolve()\n";
+      output << ' '*(indentation) << "} catch (e) {\n";
+      output << ' '*(indentation+4) << "error(e)\n";
+      output << ' '*(indentation) << "}\n";
+      indentation -= 4
+    else
+      output << ' '*(indentation+4) << "return #{output_var};\n";
+    end
     output << ' '*indentation << @children.last.strip.delete_suffix(';')
+    
     
     output << if already_assigned
       if @append

--- a/test/runtime_test.rb
+++ b/test/runtime_test.rb
@@ -200,6 +200,16 @@ class RuntimeTest < Minitest::Test
 
     assert_equal([1,2], render(t1))
   end
+  
+  test "an iterater with an async subtemplate" do
+    t1 = template(<<~EJX)
+      <% [new Promise(r => r(1)),2].forEach(async (i) => { %>
+        <span><%= await i %></span>
+      <% }) %>
+    EJX
+
+    assert_equal(['<span>1 </span>', '<span>2 </span>'], render(t1))
+  end
 end
 
 

--- a/test/subtemplate_test.rb
+++ b/test/subtemplate_test.rb
@@ -72,6 +72,43 @@ class SubtemplateTest < Minitest::Test
       }
     JS
   end
+  
+  test "an iterater with an async subtemplate" do
+    result = EJX.compile(<<~DATA)
+      <% [1,2].forEach(async (i) => { %>
+        <%= await i %>
+      <% }) %>
+    DATA
+
+    assert_equal(<<~JS.strip, result.strip)
+    import {append as __ejx_append} from 'ejx';
+
+    export default async function (locals) {
+        var __output = [], __promises = [];
+        
+        var __a = [];
+        __ejx_append([1,2].forEach(async (i) => {
+            var __b = [];
+            var resolve, error;
+            var thisPromise = new Promise((r, e) => {
+              resolve = r;
+              error = e;
+            });
+            __promises.push(thisPromise);
+            try {
+                __ejx_append(await i, __b, true, __promises);
+                __a.push(__b);
+                resolve()
+            } catch (e) {
+                error(e)
+            }
+        }), __output, true, __promises, __a);
+
+        await Promise.all(__promises);
+        return __output;
+    }
+    JS
+  end
 
   test "a simple subtemplate with a if inside it" do
     result = EJX.compile(<<~DATA)
@@ -331,4 +368,5 @@ class SubtemplateTest < Minitest::Test
       }
     JS
   end
+
 end


### PR DESCRIPTION
Add support for `forEach` subtemplates that are async render nothing. Example:
```
<% [new Promise(r => r(1)),2].forEach(async (i) => { %>
    <span><%= await i %></span>
<% }) %>
```