### PR TITLE
Async render

### DIFF
--- a/lib/ejx/assets/ejx.js
+++ b/lib/ejx/assets/ejx.js
@@ -23,28 +23,29 @@ function repalceejx(el, withItems) {
     }
 }
 
-export function append(items, to, escape, promises, promiseResults) {
+export function append(items, to, escape, unreturnedItems) {
     if ( Array.isArray(items) ) {
-        items.forEach((i) => append(i, to, escape, promises));
+        items.forEach((i) => append(i, to, escape, unreturnedItems));
     } else {
         let method = Array.isArray(to) ? 'push' : 'append';
-
         if (items instanceof Promise) {
-            let holder = document.createElement( "div");
+            let holder = document.createElement("div");
             to[method](holder);
-            promises.push( items.then((resolvedItems) => {
-                resolvedItems = resolvedItems !== undefined ? resolvedItems : promiseResults?.flat()
+            holder.__to = to;
+            
+            items.then(resolvedItems => {
+                resolvedItems = resolvedItems || unreturnedItems?.flat()
+                resolvedItems = resolvedItems === undefined ? "" : resolvedItems
+                resolvedItems = Array.isArray(resolvedItems) ? resolvedItems : [resolvedItems]
                 if (holder.parentElement) {
                     repalceejx(holder, resolvedItems || "");
-                } else if (Array.isArray(resolvedItems)) {
-                    to.splice(to.indexOf(holder), 1, ...resolvedItems);
                 } else {
-                    to.splice(to.indexOf(holder), 1, resolvedItems);
+                    holder.__to.splice(holder.__to.indexOf(holder), 1, ...resolvedItems);
                 }
-            }));
-        } else if (items === undefined && promiseResults != undefined) {
-            Promise.all(promises).then((results) => {
-                promiseResults.forEach((r) => { append(r, to, escape, promises) });
+                resolvedItems.forEach(i => {
+                    if (typeof i == "object") i.__to = holder.__to
+                })
+                delete holder.__to
             })
         } else if (typeof items === 'string') {
             if (escape) {
@@ -54,7 +55,7 @@ export function append(items, to, escape, promises, promiseResults) {
                 container.innerHTML = items;
                 to[method](...container.childNodes);
             }
-        } else {
+        } else if (items !== undefined) {
             to[method](items);
         }
 

--- a/lib/ejx/template/base.rb
+++ b/lib/ejx/template/base.rb
@@ -22,7 +22,7 @@ class EJX::Template::Base
     end
     
     output << "\nexport default async function (locals) {\n"
-    output << "    var __output = [], __promises = [];\n    \n"
+    output << "    var __output = [];\n    \n"
     
     @children.each do |child|
       output << case child
@@ -32,7 +32,6 @@ class EJX::Template::Base
         child.to_js(var_generator: var_generator)
       end
     end
-    output << "\n    await Promise.all(__promises);\n"
     output << "    return __output;\n"
     output << "}"
     output

--- a/lib/ejx/template/html_tag.rb
+++ b/lib/ejx/template/html_tag.rb
@@ -38,9 +38,10 @@ class EJX::Template::HTMLTag
       end
     end
 
+    js << "#{' '*indentation}__ejx_append(#{output_var}, #{append}, false);\n"
     @children.each do |child|
       js << if child.is_a?(EJX::Template::String)
-        "#{' '*indentation}__ejx_append(#{child.to_js}, #{output_var}, false, __promises);\n"
+        "#{' '*indentation}__ejx_append(#{child.to_js}, #{output_var}, false);\n"
       elsif child.is_a?(EJX::Template::HTMLTag)
         child.to_js(var_generator: var_generator, indentation: indentation, append: output_var, namespace: namespace)
       else
@@ -48,7 +49,6 @@ class EJX::Template::HTMLTag
       end
     end
 
-    js << "#{' '*indentation}__ejx_append(#{output_var}, #{append}, false, __promises);\n"
     js
   end
   

--- a/lib/ejx/template/js.rb
+++ b/lib/ejx/template/js.rb
@@ -12,12 +12,12 @@ class EJX::Template::JS
     
     if @modifiers.include? :escape
       if output =~ /\A\s*(var|const|let)\s+(\S+)/
-        "#{' '*indentation}#{output}#{output.strip.end_with?(';') ? '' : ';'}\n#{' '*indentation}__ejx_append(#{$2}, #{append}, true, __promises);\n"
+        "#{' '*indentation}#{output}#{output.strip.end_with?(';') ? '' : ';'}\n#{' '*indentation}__ejx_append(#{$2}, #{append}, true);\n"
       else
-        "#{' '*indentation}__ejx_append(#{output.gsub(/;\s*\Z/, '')}, #{append}, true, __promises);\n"
+        "#{' '*indentation}__ejx_append(#{output.gsub(/;\s*\Z/, '')}, #{append}, true);\n"
       end
     elsif @modifiers.include? :unescape
-      "#{' '*indentation}__ejx_append(#{output.gsub(/;\s*\Z/, '')}, #{append}, false, __promises);\n"
+      "#{' '*indentation}__ejx_append(#{output.gsub(/;\s*\Z/, '')}, #{append}, false);\n"
     elsif @modifiers.include? :comment
       "#{' '*indentation}#{output.index("\n").nil? ? "// #{output}" : "/* #{output.gsub(/\n\s+/, "\n"+(' '*indentation)+"   ")} */"}\n"
     else

--- a/lib/ejx/template/multitemplate.rb
+++ b/lib/ejx/template/multitemplate.rb
@@ -14,7 +14,7 @@ class EJX::Template::Multitemplate < EJX::Template::Subtemplate
     @children[1..-2].each do |child|
       output << case child
       when EJX::Template::String
-        "#{' '*(indentation+4)}__ejx_append(#{child.to_js}, #{append}, false, __promises);\n"
+        "#{' '*(indentation+4)}__ejx_append(#{child.to_js}, #{append}, false);\n"
       when String
         "#{' '*(indentation)}#{child}\n"
       when EJX::Template::Subtemplate
@@ -26,7 +26,7 @@ class EJX::Template::Multitemplate < EJX::Template::Subtemplate
     
     output << ' '*indentation << @children.last.strip.delete_suffix(';')
     if already_assigned
-      output << ";\n#{' '*indentation}__ejx_append(#{output_var}, #{append}, true, __promises);\n"
+      output << ";\n#{' '*indentation}__ejx_append(#{output_var}, #{append}, true);\n"
     else
       output << ", #{append}, true, __promises);\n"
     end

--- a/test/runtime_test.rb
+++ b/test/runtime_test.rb
@@ -54,6 +54,8 @@ class RuntimeTest < Minitest::Test
       }
       
       let result = template(#{JSON.generate(locals)})
+      
+      #{"setTimeout(() => {" if locals[:timeout]}
 
       if (result instanceof Promise) {
         result.then((result) => {
@@ -67,6 +69,7 @@ class RuntimeTest < Minitest::Test
         console.log(JSON.stringify({result: toHTML(result)}));
         process.exit(0);
       }
+      #{"}, #{locals[:timeout]})" if locals[:timeout]}
     JS
   end
 
@@ -87,85 +90,85 @@ class RuntimeTest < Minitest::Test
 
   test "rendering a promise that returns a string in a template" do
     t1 = template(<<~EJX)
-      <%= new Promise( (resolve) => { setTimeout(() => { resolve('hello world') }, 200); } ) %>
+      <%= new Promise( (resolve) => { setTimeout(() => { resolve('hello world') }, 10); } ) %>
     EJX
-    assert_equal(["hello world"], render(t1))
+    assert_equal(["hello world"], render(t1, timeout: 20))
 
     t2 = template(<<~EJX)
-      <div><%= new Promise( (resolve) => { setTimeout(() => { resolve('hello world') }, 200); } ) %></div>
+      <div><%= new Promise( (resolve) => { setTimeout(() => { resolve('hello world') }, 10); } ) %></div>
     EJX
-    assert_equal(["<div>hello world </div>"], render(t2))
+    assert_equal(["<div>hello world </div>"], render(t2, timeout: 20))
   end
 
   test "rendering a promise that element in a template" do
     t1 = template(<<~EJX)
-      <%= new Promise( (resolve) => { setTimeout(() => { resolve(document.createElement("div")) }, 200); } ) %>
+      <%= new Promise( (resolve) => { setTimeout(() => { resolve(document.createElement("div")) }, 10); } ) %>
     EJX
-    assert_equal(["<div></div>"], render(t1))
+    assert_equal(["<div></div>"], render(t1, timeout: 20))
 
     t2 = template(<<~EJX)
-      <div><%= new Promise( (resolve) => { setTimeout(() => { resolve(document.createElement("div")) } , 200); } ) %></div>
+      <div><%= new Promise( (resolve) => { setTimeout(() => { resolve(document.createElement("div")) } , 10); } ) %></div>
     EJX
-    assert_equal(["<div><div></div> </div>"], render(t2))
+    assert_equal(["<div><div></div> </div>"], render(t2, timeout: 20))
   end
 
   test "rendering a promise that returns an array of elements in a template" do
     t1 = template(<<~EJX)
-      <%= new Promise( (resolve) => { setTimeout(() => { resolve([document.createElement("div"), document.createElement("div")]) }, 200); } ) %>
+      <%= new Promise( (resolve) => { setTimeout(() => { resolve([document.createElement("div"), document.createElement("div")]) }, 10); } ) %>
     EJX
-    assert_equal(["<div></div>", "<div></div>"], render(t1))
+    assert_equal(["<div></div>", "<div></div>"], render(t1, timeout: 20))
 
     t2 = template(<<~EJX)
-      <div><%= new Promise( (resolve) => { setTimeout(() => { resolve([document.createElement("div"), document.createElement("div")]) } , 200); } ) %></div>
+      <div><%= new Promise( (resolve) => { setTimeout(() => { resolve([document.createElement("div"), document.createElement("div")]) } , 10); } ) %></div>
     EJX
-    assert_equal(["<div><div></div><div></div> </div>"], render(t2))
+    assert_equal(["<div><div></div><div></div> </div>"], render(t2, timeout: 20))
   end
 
   test "rendering a promise that returns an nested array of elements in a template" do
     t1 = template(<<~EJX)
-      <%= new Promise( (resolve) => { setTimeout(() => { resolve([[document.createElement("div"), document.createElement("div")]]) }, 200); } ) %>
+      <%= new Promise( (resolve) => { setTimeout(() => { resolve([[document.createElement("div"), document.createElement("div")]]) }, 10); } ) %>
     EJX
-    assert_equal([["<div></div>", "<div></div>"]], render(t1))
+    assert_equal([["<div></div>", "<div></div>"]], render(t1, timeout: 20))
 
     t2 = template(<<~EJX)
-      <div><%= new Promise( (resolve) => { setTimeout(() => { resolve([[document.createElement("div"), document.createElement("div")]]) } , 200); } ) %></div>
+      <div><%= new Promise( (resolve) => { setTimeout(() => { resolve([[document.createElement("div"), document.createElement("div")]]) } , 10); } ) %></div>
     EJX
-    assert_equal(["<div><div></div><div></div> </div>"], render(t2))
+    assert_equal(["<div><div></div><div></div> </div>"], render(t2, timeout: 20))
   end
 
   test "rendering a promise that returns a undefined" do
     t1 = template(<<~EJX)
     Hello
     <span>
-      <%= new Promise( (resolve) => { setTimeout(() => { resolve(undefined) }, 200); } ) %>
+      <%= new Promise( (resolve) => { setTimeout(() => { resolve(undefined) }, 10); } ) %>
     </span>
     World
     EJX
-    assert_equal(["Hello\n", "<span> </span>", "\nWorld"], render(t1))
+    assert_equal(["Hello\n", "<span> </span>", "\nWorld"], render(t1, timeout: 20))
   end
 
   test "rendering a promise that returns a Text Node in a template" do
     t1 = template(<<~EJX)
-      <%= new Promise( (resolve) => { setTimeout(() => { resolve(document.createTextNode("my text node")) }, 200); } ) %>
+      <%= new Promise( (resolve) => { setTimeout(() => { resolve(document.createTextNode("my text node")) }, 10); } ) %>
     EJX
-    assert_equal(["my text node"], render(t1))
+    assert_equal(["my text node"], render(t1, timeout: 20))
 
     t2 = template(<<~EJX)
-      <div><%= new Promise( (resolve) => { setTimeout(() => { resolve(document.createTextNode("my text node")) }, 200); } ) %></div>
+      <div><%= new Promise( (resolve) => { setTimeout(() => { resolve(document.createTextNode("my text node")) }, 10); } ) %></div>
     EJX
-    assert_equal(["<div>my text node </div>"], render(t2))
+    assert_equal(["<div>my text node </div>"], render(t2, timeout: 20))
   end
 
   test "rendering another template that has a promise inside a template" do
     t1 = template(<<~EJX)
-      <%= new Promise( (resolve) => { setTimeout(() => { resolve('hello') }, 200); } ) %>
+      <%= new Promise( (resolve) => { setTimeout(() => { resolve('hello') }, 10); } ) %>
     EJX
     t2 = template(<<~EJX)
       <% import t1 from "#{t1}"; %>
       <%= t1() %> world
     EJX
-    assert_equal(["hello"], render(t1))
-    assert_equal(["hello", " world"], render(t2))
+    assert_equal(["hello"], render(t1, timeout: 20))
+    assert_equal(["hello", " world"], render(t2, timeout: 50))
   end
 
   test "including an HTML string" do
@@ -179,7 +182,7 @@ class RuntimeTest < Minitest::Test
   test "rendering a subtemplate in a promise" do
     t1 = template(<<~EJX)
       <% var formTag = function(template) {
-           return new Promise( (resolve) => { setTimeout(() => { resolve(template()) }, 200); } );
+           return new Promise( (resolve) => { setTimeout(() => { resolve(template()) }, 10); } );
          } %>
 
       <form>
@@ -190,7 +193,7 @@ class RuntimeTest < Minitest::Test
       </form>
     EJX
 
-    assert_equal([' ', '<form><input type="text"><input type="submit"></form>'], render(t1))
+    assert_equal([' ', '<form><input type="text"><input type="submit"></form>'], render(t1, timeout: 20))
   end
 
   test "a forEach subtemplate" do
@@ -248,17 +251,15 @@ class RuntimeTest < Minitest::Test
         <tr>
         <% row = await row %>
         <% row.forEach(async cell => { %>
-          <% const v = await cell %>
-          <% console.error('^^', v) %>
-          <td><%= v %></td>
+          <td><%= await cell %></td>
         <% }) %>
         </tr>
       <% }) %>
       </table>
     EJX
 
-    assert_equal([" ", "<table><tr><td>1 </td><td>2 </td></tr><tr><td>3 </td><td>4 </td></tr></table>"], render(t1))
-    
+    assert_equal([" ", "<table><tr><td>1 </td><td>2 </td></tr><tr><td>3 </td><td>4 </td></tr></table>"], render(t1, timeout: 200))
+
     #TODO test array.forEach lower in nesting inside promises, might result in top Promises.all, which appends overall array, running before Promises.all of lower level append
   end
 
@@ -281,7 +282,7 @@ class RuntimeTest < Minitest::Test
       <% }) %>
     EJX
 
-    assert_equal(['<span>1 </span>', '<span>2 </span>'], render(t1))
+    assert_equal(['<span>1 </span>', '<span>2 </span>'], render(t1, timeout: 10))
   end
 
   test "an iterater that is a promise" do


### PR DESCRIPTION
This change adds a clean way to have subtemplates handling their own promises, but means the resulting ejx function will return an array that is possibly still being rendered into via promises.

TODO - Update Subtemplate tests